### PR TITLE
Added default valut on every query and request params

### DIFF
--- a/src/Controller/AuthenticationController.php
+++ b/src/Controller/AuthenticationController.php
@@ -72,17 +72,17 @@ class AuthenticationController extends AbstractController
         }
 
         if ('POST' === $request->getMethod()) {
-            $token = $request->request->get('_csrf_token');
+            $token = $request->request->get('_csrf_token', '');
 
             if (!$this->isCsrfTokenValid('register', $token)) {
                 throw ExceptionFactory::throw(InvalidCsrfTokenException::class, ExceptionCode::INVALID_CSRF_TOKEN, 'Invalid CSRF token');
             }
 
             $error = false;
-            $email = $request->request->get('email');
-            $username = $request->request->get('username');
-            $password = $request->request->get('password');
-            $passwordConfirm = $request->request->get('passwordConf');
+            $email = $request->request->get('email', '');
+            $username = $request->request->get('username', '');
+            $password = $request->request->get('password', '');
+            $passwordConfirm = $request->request->get('passwordConf', '');
 
             if ($password !== $passwordConfirm) {
                 $error = true;

--- a/src/Controller/NewsletterController.php
+++ b/src/Controller/NewsletterController.php
@@ -50,7 +50,7 @@ class NewsletterController extends AbstractController
             }
 
             $account = new NewsletterAccount();
-            $account->setEmail($request->request->get('email'));
+            $account->setEmail($request->request->get('email', ''));
 
             $this->em->persist($account);
             $this->em->flush();
@@ -64,7 +64,7 @@ class NewsletterController extends AbstractController
     #[Route('/verification/pending', methods: ['GET'], name: 'app_newsletter_verification_pending')]
     public function accountVerificationPending(Request $request)
     {
-        $token = $request->query->get('token');
+        $token = $request->query->get('token', '');
         $account = $this->newsletterService->verifyTokenAndGetAccount($token);
 
         if ($account->getIsVerified()) {
@@ -88,7 +88,7 @@ class NewsletterController extends AbstractController
     #[Route('/verification/confirm', methods: ['GET'], name: 'app_newsletter_verification_confirm')]
     public function accountVerificationConfirmation(Request $request)
     {
-        $token = $request->query->get('token');
+        $token = $request->query->get('token', '');
         $account = $this->newsletterService->verifyTokenAndGetAccount($token);
 
         if (!$account->getIsVerified()) {
@@ -107,7 +107,7 @@ class NewsletterController extends AbstractController
     #[Route('/verification/completed', methods: ['GET'], name: 'app_newsletter_verification_completed')]
     public function accountVerificationCompleted(Request $request)
     {
-        $token = $request->query->get('token');
+        $token = $request->query->get('token', '');
         $account = $this->newsletterService->verifyTokenAndGetAccount($token);
 
         if (!$account->getIsVerified()) {
@@ -122,7 +122,7 @@ class NewsletterController extends AbstractController
     #[Route('/unsubscribe', methods: ['GET'], name: 'app_newsletter_unsubscribe')]
     public function unsubscribe(Request $request, NewsletterAccountRepository $newsletterAccountRepository)
     {
-        $token = $request->query->get('token');
+        $token = $request->query->get('token', '');
         $account = $this->newsletterService->verifyTokenAndGetAccount($token);
 
         $newsletterAccountRepository->remove($account, true);

--- a/src/Security/AppAuthenticator.php
+++ b/src/Security/AppAuthenticator.php
@@ -49,7 +49,7 @@ class AppAuthenticator extends AbstractLoginFormAuthenticator
             new UserBadge($identifier),
             new PasswordCredentials($request->request->get('password', '')),
             [
-                new CsrfTokenBadge('authenticate', $request->request->get('_csrf_token')),
+                new CsrfTokenBadge('authenticate', $request->request->get('_csrf_token', '')),
                 new RememberMeBadge(),
             ]
         );

--- a/src/Service/Newsletter/NewsletterService.php
+++ b/src/Service/Newsletter/NewsletterService.php
@@ -48,9 +48,10 @@ class NewsletterService
     public function validateRegistrationRequestParam(Request $request): bool
     {
         $hasError = false;
-        $email = $request->request->get('email');
-        $agree = $request->request->get('agree');
-        $csrf = $request->request->get('_csrf_token');
+
+        $email = $request->request->get('email', '');
+        $agree = $request->request->get('agree', '');
+        $csrf = $request->request->get('_csrf_token', '');
 
         /** @var Session $session */
         $session = $this->requestStack->getSession();
@@ -61,7 +62,7 @@ class NewsletterService
             $session->getFlashBag()->add('error', $this->translator->trans('newsletter_account.form.csrf', domain: 'validators'));
         }
 
-        if (null === $agree || 'on' !== $agree) {
+        if ('on' !== $agree) {
             $hasError = true;
             $session->getFlashBag()->add('error', $this->translator->trans('newsletter_account.form.agree', domain: 'validators'));
         }

--- a/translations/validators/validators.en.yaml
+++ b/translations/validators/validators.en.yaml
@@ -45,6 +45,7 @@ newsletter_account.email.not_blank: "The email can not be blank"
 newsletter_account.email.email: "Invalid email"
 newsletter_account.email.length: "The email can not exceed {{ limit }} characters"
 newsletter_account.form.csrf: "Invalid CSRF token"
+newsletter_account.form.email: "Invalid email"
 newsletter_account.form.agree: "You must accept the terms of use to register"
 
 banner.content.length: "The content of a banner can not exceed {{ limit }} characters"

--- a/translations/validators/validators.fr.yaml
+++ b/translations/validators/validators.fr.yaml
@@ -45,6 +45,7 @@ newsletter_account.email.not_blank: "L'email ne peut pas être vide"
 newsletter_account.email.email: "Email invalide"
 newsletter_account.email.length: "L'email ne peut pas dépasser {{ limit }} caractère"
 newsletter_account.form.csrf: "Token CSRF invalide"
+newsletter_account.form.email: "Email invalide"
 newsletter_account.form.agree: "Vous devez accepter les conditions d'utilisation pour vous enregistrer"
 
 banner.content.length: "Le contenu d'une bannière ne peut pas dépasser {{ limit }} caractères"


### PR DESCRIPTION
## Description

- To prevent unwanted 500 errors, I added default value on $request->request and $request->query methods

## Checklist

Check that each item in the following list is respected before performing a merge.

- [x] `Type` and `Release` are correctly chosen
- [x] The merge request is created from the right branch and targets the right branch
- [x] Code is correctly factored (no code duplication)
- [x] Variable and function names make sense
- [x] There are enough comments when the code is complicated
